### PR TITLE
Restore HDI country data. IE fixes.

### DIFF
--- a/_includes/views/Filters.js
+++ b/_includes/views/Filters.js
@@ -109,6 +109,14 @@ views.Filters = Backbone.View.extend({
                 } else {
                     view.$el.empty();
                 }
+
+                if (app.filtercounter !== facets.length ) {
+                    app.filtercounter = (app.filtercounter) ? app.filtercounter + 1 : 2;
+                } else {
+                    app.filtercounter = 0;
+                    app.projects.map.render();
+                }
+
             }
     
             $('#chart-' + view.collection.id + '.rows').empty();

--- a/css/style.css
+++ b/css/style.css
@@ -1600,7 +1600,5 @@ Details: http: //perishablepress.com/press/2009/12/06/new-clearfix-hack*/
   filter: alpha(opacity=100);
   }
 
-body.ie .inner-shadow,
-body.ie9 .inner-shadow {
-  display: none;
-  }
+body.ie .inner-shadow { display: none; }
+body.ie8 #chart-hdi .details { display: none; }

--- a/embed.html
+++ b/embed.html
@@ -18,8 +18,9 @@
 <!--[if lt IE 7 ]> <body class='ie ie6'> <![endif]-->
 <!--[if IE 7 ]>    <body class='ie ie7'> <![endif]-->
 <!--[if IE 8 ]>    <body class='ie ie8'> <![endif]-->
-<!--[if IE 9 ]>    <body class='ie9'> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]> <!-->
+<!--[if IE 9 ]>    <body class='ie ie9'> <![endif]-->
+<!--[if IE 10 ]>   <body class='ie ie10'> <![endif]-->
+<!--[if gt IE 10]><!-->
 <body>
 <!--<![endif]-->
 

--- a/ext/clustr.min.js
+++ b/ext/clustr.min.js
@@ -85,7 +85,7 @@ clustr.scale_factory = function(getRadius, fillStyle, strokeStyle) {
         getRadius = clustr.functor(getRadius);
 
         var radius = getRadius(feature),
-            diameter = radius * 2;
+            diameter = radius * 2 || 0;
 
         if (!scale_factory_cache[radius + fillStyle]) {
             var c = document.createElement('canvas');

--- a/index.html
+++ b/index.html
@@ -35,8 +35,9 @@
 <!--[if lt IE 7 ]> <body class='ie ie6'> <![endif]-->
 <!--[if IE 7 ]>    <body class='ie ie7'> <![endif]-->
 <!--[if IE 8 ]>    <body class='ie ie8'> <![endif]-->
-<!--[if IE 9 ]>    <body class='ie9'> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]> <!-->
+<!--[if IE 9 ]>    <body class='ie ie9'> <![endif]-->
+<!--[if IE 10 ]>   <body class='ie ie10'> <![endif]-->
+<!--[if gt IE 10]><!-->
 <body>
 <!--<![endif]-->
 


### PR DESCRIPTION
Callback for HDI data. Fixes #142. IE fixes: hide HDI chart in IE8, set default marker size to 0 (was showing as broken image in IE9), remove shadow from map for all IE version (IE10 seems to ignore conditional comments
