### PR TITLE
Hotfixes for expenditure chart and map rendering

### DIFF
--- a/_includes/views/Chart.js
+++ b/_includes/views/Chart.js
@@ -35,12 +35,6 @@ function renderFocusAreaChart(chartData, rootPath, view) {
     $el.prepend('<h3 id="focus">Themes <span>% of budget</span></h3>');
 }
 
-function setMapInfo(donorInfo, model, budgetSource) {
-    if (budgetSource) global.projects.map.collection.donorID = false;
-    global.projects.map.collection.operating_unitBudget[model.get('id')] = donorInfo.budget;
-    global.projects.map.collection.operating_unitExpenditure[model.get('id')] = donorInfo.expenditure;      
-}
-
 function setBudgetHTML(donorInfo, model, notOperatingUnit, pathTo) {
     var donorBudget = donorInfo.budget;
     var donorExpenditure = donorInfo.expenditure;
@@ -107,13 +101,15 @@ function renderBudgetSourcesChart(donor, donorCountrySelected, chartData, view, 
         donorInfo.budget = _(donorProjects).chain().pluck('budget')
             .reduce(function(memo, num){ return memo + num; }, 0).value();
 
-        donorInfo.budget = _(donorProjects).chain().pluck('expenditure')
+        donorInfo.expenditure = _(donorProjects).chain().pluck('expenditure')
             .reduce(function(memo, num){ return memo + num; }, 0).value();     
 
         var notOperatingUnit = (donor || donorCountrySelected);
 
         if (notOperatingUnit) {
-            setMapInfo(donorInfo, model, donor);
+            if (donor) global.projects.map.collection.donorID = false;      
+            global.projects.map.collection.donorBudget[donor] = donorInfo.budget;
+            global.projects.map.collection.donorExpenditure[donor] = donorInfo.expenditure;
         }
 
         var row = setBudgetHTML(donorInfo, model, notOperatingUnit, pathTo);
@@ -155,7 +151,10 @@ function renderRecipientOfficesChart(donor, donorCountrySelected, chartData, vie
         var notOperatingUnit = (donor || donorCountrySelected);
 
         if (notOperatingUnit) {
-            setMapInfo(donorInfo, model, donor);
+            if (donor) global.projects.map.collection.donorID = false;
+            global.projects.map.collection.operating_unitBudget[model.get('id')] = donorInfo.budget;
+            global.projects.map.collection.operating_unitExpenditure[model.get('id')] = donorInfo.expenditure;
+            console.log(model.get('id') + ", " + global.projects.map.collection.operating_unitBudget[model.get('id')]) ; 
         }
 
         var row = setBudgetHTML(donorInfo, model, notOperatingUnit, pathTo);

--- a/_includes/views/Filters.js
+++ b/_includes/views/Filters.js
@@ -164,18 +164,16 @@ views.Filters = Backbone.View.extend({
                         return filter.collection === 'donor_countries';
                     }) || {id: 0}).id;
 
-
                 if (view.collection.id === 'focus_area') {
                     chartModels = view.collection.models;
-                    renderFocusAreaChart(chartModels, pathTo, view);
+                    setTimeout(function() {renderFocusAreaChart(chartModels, pathTo, view)},0);
 
                 } else if ( view.collection.id === 'donors' ){
                     view.chartModels = chartModels;
-                    renderBudgetSourcesChart(donor, donor_ctry, chartModels, view, pathTo) 
-
+                    setTimeout(function() {renderBudgetSourcesChart(donor, donor_ctry, chartModels, view, pathTo)},0);
                 } else if (view.collection.id === 'operating_unit' || view.collection.id === 'donor_countries') {
                     view.chartModels = chartModels;
-                    renderRecipientOfficesChart(donor, donor_ctry, chartModels, view, pathTo) 
+                    setTimeout(function() {renderRecipientOfficesChart(donor, donor_ctry, chartModels, view, pathTo) },0);
                 }
             }
         }, 0);


### PR DESCRIPTION
The expenditure chart fix was a typo in `Chart.js` at line 110.

The map bug is related to rendering order. Since the budget calculations are done in the charts, we need to render the map afterwards. By adding `setTimeout`s we can force the rendering. Ideally, render order should be addressed in the refactor. 

cc @smit1678 @jueyang 
