### PR TITLE
Embed fixes

### DIFF
--- a/_includes/templates.html
+++ b/_includes/templates.html
@@ -42,6 +42,25 @@
   </tr>
 </script>
 
+<script id='embedFocusAreaItemTemplate' type='text/html'>
+  <li class='focus fa<%= id %>'>
+    <a target="_blank" href='<%= path %>' class='focus-title'> <%= focusName %> </a>
+    <p class='pct'><span class='<%= focusIconClass %>'></span></p>
+  </li>
+</script>
+
+
+<script id='embedBudgetChartItemTemplate' type='text/html'>
+  <tr>
+    <td><a target="_blank" href='<%= path %>'><%= name %></a></td>
+    <td class='right'><%= budget %></td>
+    <td class='data'>
+      <div class='budgetdata' data-budget='<%= budgetWidth %>'></div>
+      <div class='subdata' data-expenditure='<%= expenditureWidth %>'></div>
+    </td>
+  </tr>
+</script>
+
 <!-- Google Analytics -->
 <script type="text/javascript">
 

--- a/_includes/templates/embedProject._
+++ b/_includes/templates/embedProject._
@@ -1,5 +1,6 @@
 <tr id="project-<%= model.get('id') %>">
-    <td><a target='_blank' href="<%= BASE_URL %>#project/<%= model.get('id') %>"><%= model.get('name').toLowerCase().toTitleCase() %></a></td>
+    <td><a target='_blank' href="/#project/<%= model.get('id') %>"><%= model.get('name').toLowerCase().toTitleCase() %></a></td>
     <td><%= model.get('budget') %></td>
     <td><%= model.get('expenditure') %></td>
 </tr>
+

--- a/_includes/templates/embedProjects._
+++ b/_includes/templates/embedProjects._
@@ -56,15 +56,34 @@
       <div class='row-fluid'>
         <!--Chart Four -->
         <div class='span6 chart stat-chart' id='chart-operating_unit'>
-          <h3>Top Recipient Offices</h3>
-          <span class='chart-legend'>
-            <div class='thick-bar clearfix'><span></span>Budget</div>
-            <div class='thin-bar'><span></span>Expense</div>
-          </span>
-          <table class='table table-unstyled'>
-            <tbody class='rows'></tbody>
-          </table>
-        </div>
+            <h3>Top Recipient Offices</h3>
+            <span class='chart-legend'>
+              <div class='thick-bar clearfix'><span></span>Budget</div>
+              <div class='thin-bar'><span></span>Expense</div>
+            </span>
+            <ul class="nav nav-tabs">
+              <li class="active"><a href="#partnerTab" data-toggle='tab'>Partner Resources</a></li>
+              <li><a href="#localTab" data-toggle='tab'>Local Resources</a></li>
+              <li><a href="#readMore" data-toggle='tab'>Read More</a></li>
+            </ul>
+            <div>
+              <div class="tab-content">
+                <div class='tab-pane active' id='partnerTab'>
+                  <table class='table table-unstyled'>
+                    <tbody class='rows'></tbody>
+                  </table>
+                </div>
+                <div class='tab-pane' id='localTab'>
+                  <table class='table table-unstyled'>
+                    <tbody class='rows'></tbody>
+                  </table>
+                </div>
+                <div class='tab-pane' id='readMore'>
+                  <p>The ranking of the top recipient offices includes funding originating <b>from within the country</b>. Country offices such as Argentina is listed as a local resource recipient because it receives funding from domestic organizations.</p>
+                </div>
+              </div>
+            </div>
+          </div>
         <div class='span6 chart stat-chart' id='chart-donors'>
           <h3>Top Budget Sources</h3>
           <span class='chart-legend'>

--- a/_includes/views/App.js
+++ b/_includes/views/App.js
@@ -330,7 +330,7 @@ views.App = Backbone.View.extend({
 
         $('.widget-preview', el).html(defaultIframe);
         $('.widget-code', el)
-            .val(defaultIframe.replace('src="{{site.baseurl}}/','src="' + BASE_URL))
+            .val(defaultIframe.replace('src="{{site.baseurl}}/','src="' + Backbone.history.location.origin + '/'))
             .select();
     }
 });

--- a/_includes/views/Chart.js
+++ b/_includes/views/Chart.js
@@ -2,14 +2,25 @@ function renderFocusAreaChart(chartData, rootPath, view) {
     var $el = $('#chart-focus_area');
     $el.empty();
     
+    this.pageType = Backbone.history.location.hash.split('/')[1];
+    console.log(this.pageType);
+
     // Calculate budget for each focus area
     var totalBudget = _(chartData).reduce(function(budget, focusArea) {
         return budget + (focusArea.get('budget') || 0);
     }, 0) || 0;
 
+    var pageType = Backbone.history.location.hash.split('/')[1];
 
-    // For each focus area, fill the template with the percentage value
-    var template = _.template($("#focusAreaItemTemplate").html());
+    // Template for each row
+    var template = '';
+    var pageType = Backbone.history.location.hash.split('/')[1];
+    if (pageType === 'widget') {
+        template = _.template($("#embedFocusAreaItemTemplate").html());
+    } else {
+        template = _.template($("#focusAreaItemTemplate").html());
+    }
+
     _(chartData).each(function(model, index) {
         var focusIconClass = model.get('name').replace(/\s+/g, '-').toLowerCase().split('-')[0];
         var focusName = model.get('name').toLowerCase().toTitleCase();
@@ -46,7 +57,13 @@ function setBudgetHTML(donorInfo, model, notOperatingUnit, pathTo) {
     var donorExpenditure = donorInfo.expenditure;
 
     //Template of chart row
-    var chartTemplate = _.template($("#budgetChartItemTemplate").html()); 
+    var chartTemplate = '';
+    var pageType = Backbone.history.location.hash.split('/')[1];
+    if (pageType === 'widget') {
+        chartTemplate = _.template($("#embedBudgetChartItemTemplate").html());
+    } else {
+        chartTemplate = _.template($("#budgetChartItemTemplate").html());
+    }
 
     var budget = accounting.formatMoney(
             ((notOperatingUnit) ? donorBudget : model.get('budget')),"$", 0, ",", "."

--- a/_includes/views/Filters.js
+++ b/_includes/views/Filters.js
@@ -134,11 +134,16 @@ views.Filters = Backbone.View.extend({
             }
     
             // Root path of links for each chart item
+            var pathTo;
             if (global.processedFacets.length === 0 ){
-                var pathTo = '#' + CURRENT_YR +'/filter/';
+                pathTo = '#' + CURRENT_YR +'/filter/';
             } else {
-                pathTo = document.location.hash + "/";
+                pathTo = document.location.hash
+
+                //Creates proper link for embedded chart items
+                pathTo = (pathTo.split('?')[0] + '/').replace('widget', 'filter')
             };
+            pathTo = BASE_URL + pathTo;
 
             //If we don't have any data for that chart don't render it
             if (chartModels.length <= 1 && view.collection.id !== 'focus_area' && !donorCountry) {

--- a/_includes/views/ProjectProfile.js
+++ b/_includes/views/ProjectProfile.js
@@ -205,7 +205,7 @@ views.ProjectProfile = Backbone.View.extend({
 
         $('.widget-preview', el).html(defaultIframe); // this is where the json is getting called
         $('.widget-code', el)
-            .val(defaultIframe.replace('src="{{site.baseurl}}/','src="' + BASE_URL))
+            .val(defaultIframe.replace('src="{{site.baseurl}}/','src="' + Backbone.history.location.origin + '/'))
             .select();
     }
 });

--- a/_includes/views/Widget.js
+++ b/_includes/views/Widget.js
@@ -79,7 +79,7 @@ views.Widget = Backbone.View.extend({
 
             $('.widget-preview', view.$el).html(view.widgetCode);
             $('.widget-code', view.$el)
-                .val(view.widgetCode.replace('src="{{site.baseurl}}/','src="' + BASE_URL))
+                .val(view.widgetCode.replace('src="{{site.baseurl}}/','src="' + Backbone.history.location.origin + '/'))
                 .select();
         } else {
             $('.widget-preview', view.$el).html('<h3 class="empty">To use this widget choose options from above.</h3>');

--- a/js/script.js
+++ b/js/script.js
@@ -1,7 +1,7 @@
 ---
 ---
 var CURRENT_YR = FISCALYEARS[0],
-    BASE_URL = '{{site.baseurl}}',
+    BASE_URL = '/',
     MAPID = "undp.map-6grwd0n3";
 
 var IE = $.browser.msie;
@@ -17,6 +17,7 @@ util.ctyBounds = function(coords) {
         var polyline = L.polyline(coords[0]);
     }
     var bbox = polyline.getBounds();
+
 
     return [[bbox.getSouthWest().lng, bbox.getSouthWest().lat],
             [bbox.getNorthEast().lng, bbox.getNorthEast().lat]];


### PR DESCRIPTION
## Fix for #69 

The template code for embeds is a different file, so I merged in the new table code from the main app template.
## Fix for #57 

This is a messy error related to `BASE_URL` which was hardcoded to http://open.undp.org, I replaced that variable in many places with `Backbone.history.location.origin`. 

Since the embed also creates links of the form `http://open.undp.org/embed.html#2014/widget/?title&charts&projects&map` you have to manipulate the string to generate a proper non-embed path link such as `http://open.undp.org/#2014/filter/`.

Additionally, if you're in an embed view, all links will open a new page (`target='_blank'`)
## Refactoring

For future refactoring, we need to look at where `BASE_URL` and `"{{site.baseurl}}" and see if they still make sense when we have`Backbone.history.location.origin`.
