### PR TITLE
Fix for #122

### DIFF
--- a/_includes/views/Map.js
+++ b/_includes/views/Map.js
@@ -317,8 +317,9 @@ views.Map = Backbone.View.extend({
         //If a donor country is selected, we don't want to specify a distinction between
         //Local and partner resources
         var donorCountry = _(global.processedFacets).where({ collection: 'donor_countries' });
+        if (!donorCountry.length) { donorCountry = _(global.processedFacets).where({ collection: 'donors' });}
         donorCountry = (donorCountry.length) ? donorCountry[0].id : false;
-
+        console.log(donorCountry)
         var view = this;
         var count, sources, budget, title, hdi, hdi_health, hdi_education, hdi_income,
             unit = view.collection,
@@ -445,7 +446,7 @@ views.Map = Backbone.View.extend({
                                     return project.get('operating_unit')  === e.target.feature.properties.id;
                                 })
                                 .filter(function(project) { return _(project.get('donor_countries'))
-                                    .contains(donorCountry) 
+                                    .contains(donorCountry) || _(project.get('donors')).contains(donorCountry)
                                 }).value().length > 0)  
                             {
                                 path = prevPath + '/operating_unit-' +  e.target.feature.properties.id;


### PR DESCRIPTION
#122 : Budget source bug

When clicking on a bubble, search if donors & donors_countries contains the processed facet, and if it doesn't default to UNDP Regular resources.

This is because we add UNDP Regular Resources bubbles for core donors; core donors can be countries or budget sources. When clicking on a bubble we were only checking if the bubble donors contain the selection in the country filter (and not the budget source filter). 

cc @smit1678 
