### PR TITLE
Fix broken header links

### DIFF
--- a/_includes/global-header.html
+++ b/_includes/global-header.html
@@ -185,7 +185,7 @@ Find details on our successes and ongoing work.</p>
 </div>  
 </div>
 </li>
-<li><a href="http://www.undp.org/content/undp/en/home/about-us.html">About us</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/publications.html">Publications</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/news-centre.html">News Centre</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding.html">Funding &#x25BE;</a><div><div class="nav-column"><ul><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/top-contributors.html">Top contributors</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/funding-channels.html">Funding channels</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/partners.html">Partners</a></li></ul></div></div></li></ul>
+<li><a href="http://www.undp.org/content/undp/en/home/about-us.html">About us</a></li><li><a href="http://www.undp.org/content/undp/en/home/library.html">Publications</a></li><li><a href="http://www.undp.org/content/undp/en/home/news-centre.html">News Centre</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding.html">Funding &#x25BE;</a><div><div class="nav-column"><ul><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/top-contributors.html">Top contributors</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/funding-channels.html">Funding channels</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/partners.html">Partners</a></li></ul></div></div></li></ul>
 </div>            
             
             

--- a/_includes/global-header.html
+++ b/_includes/global-header.html
@@ -185,7 +185,7 @@ Find details on our successes and ongoing work.</p>
 </div>  
 </div>
 </li>
-<li><a href="http://www.undp.org/content/undp/en/home/menu/about-us.html">About us</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/publications.html">Publications</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/news-centre.html">News Centre</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding.html">Funding &#x25BE;</a><div><div class="nav-column"><ul><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/top-contributors.html">Top contributors</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/funding-channels.html">Funding channels</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/partners.html">Partners</a></li></ul></div></div></li></ul>
+<li><a href="http://www.undp.org/content/undp/en/home/about-us.html">About us</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/publications.html">Publications</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/news-centre.html">News Centre</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding.html">Funding &#x25BE;</a><div><div class="nav-column"><ul><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/top-contributors.html">Top contributors</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/funding-channels.html">Funding channels</a></li><li><a href="http://www.undp.org/content/undp/en/home/menu/funding/partners.html">Partners</a></li></ul></div></div></li></ul>
 </div>            
             
             


### PR DESCRIPTION
Long story short, I came across this site while reading https://developmentseed.org/blog/2013/05/01/introducing-jekyll-hook/ and noticed the About Us link was broken. After fixing it, I subsequently noticed virtually every link on this line is stale. This PR fixes the About Us, Publications, and News Centre links. All other links should be manually verified and updated as necessary.

P.S. Keep up the awesome work!